### PR TITLE
Use requirements file when running setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado>=3.2
+tornado>=3.2,<=5.1
 couchdb>=0.8
 pyyaml>=3.10
 pycountry>=1.5

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,20 @@
 
 from setuptools import setup
 
+try:
+    with open("requirements.txt", "r") as f:
+        install_requires = [x.strip() for x in f.readlines()]
+except IOError:
+    install_requires = []
+
 setup(name='userman',
       version='14.7',
       description='Simple account handling system for use with web services.',
       license='MIT',
       author='Per Kraulis',
       author_email='per.kraulis@scilifelab.se',
-      url='https://github.com/pekrau/userman',
+      url='https://github.com/NationalGenomicsInfrastructure/userman',
       packages=['userman'],
       include_package_data=True,
-      install_requires=['tornado>=3.2',
-                        'couchdb>=0.8',
-                        'pyyaml>=3.10',
-                        'pycountry>=1.5',
-                        'requests>=2.2'],
+      install_requires=install_requires
      )


### PR DESCRIPTION
* Use the included requirements file when running setup.py
* Tornado versions greater than 6 will not run on Python 2.7